### PR TITLE
footer 포지션 고정을 위해서 Postlist에 min-height속성 추가

### DIFF
--- a/logbook/logbook-frontend/src/components/posts/PostList.js
+++ b/logbook/logbook-frontend/src/components/posts/PostList.js
@@ -8,6 +8,7 @@ import {Link} from 'react-router-dom';
 
 const PostListBlock = styled(Responsive)`
 	margin-top: 3rem;
+	min-height: calc(100vh - 258px - 3rem);
 `;
 
 const WritePostButtonWrapper = styled.div`


### PR DESCRIPTION
이걸로 이슈 열었었는데 결국은 간단한 방식인 Postlist의 min-height를 주는 방식으로 해결하였습니다.

min-height: calc(100vh - 258px - 3rem)
으로 주었는데,
100vh는 모니터 높이이고, 여기서 나머지 높이 header와 footer의 높이를 inspector에서 따왔습니다.
64px의 header높이
평균 144px + 25px * 2의 footer높이
(가변적입니다만, 브라우저 배율에만 영향을 받아서 신경 안 써도 될 듯합니다. 오차는 -5~+5px 정도),
3rem의 Postlist의 자체 margin-top을 제외하여 이렇게 만들었습니다.

firefox, chrome, edge에서 검사했고 렌더링 잘 됩니다.
iex환경은 일단 애초에 렌더링이 안되는데 이건 원래 그런 듯합니다.
리뷰 부탁드립니다~
